### PR TITLE
Add 10 second delay after agent init

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import axios from "axios"
 
-import { ConfigOptions } from "@bearer/node-agent/lib/config"
 import Dotenv from "dotenv"
 
 Dotenv.config()
@@ -10,9 +9,7 @@ import Bearer from "@bearer/node-agent"
 const { BEARER_SECRET_KEY } = process.env
 
 const body = async () => {
-  await Bearer.init({
-    secretKey: BEARER_SECRET_KEY,
-  } as ConfigOptions)
+  await Bearer.init({ secretKey: BEARER_SECRET_KEY })
 
   console.log("-- Waiting for initialization --")
   await sleep(10000)

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,9 @@ const body = async () => {
     secretKey: BEARER_SECRET_KEY,
   } as ConfigOptions)
 
+  console.log("-- Waiting for initialization --")
+  await sleep(10000)
+
   // Postman-Echo
   console.log("-- Sending API Calls to Postman-echo --")
   try {
@@ -84,5 +87,7 @@ const body = async () => {
     await axios.get("https://foo.bar/status/200")
   } catch {}
 }
+
+const sleep = (msec: number) => new Promise(resolve => { setTimeout(resolve, msec) })
 
 body()


### PR DESCRIPTION
Environments are created asynchronously on the back-end. We must wait for that to happen so that all built-in rules have been created and sent to the agent.

This is a temporary measure until we fix this properly.